### PR TITLE
Add (SelectComponent) Headless UI select created

### DIFF
--- a/icpc-frontned/src/app/components/dropdowns/SelectComponent.tsx
+++ b/icpc-frontned/src/app/components/dropdowns/SelectComponent.tsx
@@ -1,0 +1,117 @@
+import { Fragment } from 'react'
+import { Listbox, Transition } from '@headlessui/react'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid'
+import { TextComponent } from '../text/TextComponent'
+import { enumTextTags } from '@/constants/types'
+import { FieldValues, UseFormRegister } from 'react-hook-form'
+import React from 'react'
+
+interface ISelectProps {
+  options: {
+    id: number
+    name: string
+  }[]
+  fieldName: string
+  labelText: string
+  necessary: boolean
+  register: UseFormRegister<FieldValues>
+  selected: string
+  onChange: (value: string) => void
+}
+
+function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ')
+}
+
+export function SelectComponent({ ...props }: Readonly<ISelectProps>) {
+  const reference = React.useRef<HTMLSelectElement | null>(null)
+  return (
+    <>
+      <select
+        className='hidden'
+        ref={reference}
+      />
+      <Listbox
+        value={props.selected}
+        onChange={newSelected => {
+          props.onChange(newSelected)
+          if (reference.current) {
+            reference.current.dispatchEvent(new Event('change', { bubbles: true }))
+          }
+        }}
+        name={props.fieldName}>
+        {({ open }) => (
+          <>
+            <TextComponent
+              tag={enumTextTags.p}
+              className='block text-sm font-medium leading-6 text-gray-900'>
+              {props.labelText}
+            </TextComponent>
+            <div className='relative mt-2'>
+              <Listbox.Button
+                className={`relative w-full cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left 
+                  text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                  sm:text-sm sm:leading-6`}>
+                <span className='flex items-center'>
+                  <span className='ml-3 block truncate'>{props.selected}</span>
+                </span>
+                <span className='pointer-events-none absolute inset-y-0 right-0 ml-3 flex items-center pr-2'>
+                  <ChevronUpDownIcon
+                    className='h-5 w-5 text-gray-400'
+                    aria-hidden='true'
+                  />
+                </span>
+              </Listbox.Button>
+
+              <Transition
+                show={open}
+                as={Fragment}
+                leave='transition ease-in duration-100'
+                leaveFrom='opacity-100'
+                leaveTo='opacity-0'>
+                <Listbox.Options
+                  className={`absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base 
+                          shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm`}>
+                  {props.options.map(option => (
+                    <Listbox.Option
+                      key={option.id}
+                      className={({ active }) =>
+                        classNames(
+                          active ? 'dark:bg-secondary bg-gray-100 text-secondary dark:text-white' : 'text-gray-900',
+                          'relative cursor-default select-none py-2 pl-3 pr-9'
+                        )
+                      }
+                      value={option.name}>
+                      {({ selected, active }) => (
+                        <>
+                          <div className='flex items-center'>
+                            <span className={classNames(selected ? 'font-semibold' : 'font-normal', 'ml-3 block truncate')}>
+                              {option.name}
+                            </span>
+                          </div>
+
+                          {selected ? (
+                            <span
+                              className={classNames(
+                                active ? 'text-white' : 'text-indigo-600',
+                                'absolute inset-y-0 right-0 flex items-center pr-4'
+                              )}>
+                              <CheckIcon
+                                className='h-5 w-5'
+                                aria-hidden='true'
+                              />
+                            </span>
+                          ) : null}
+                        </>
+                      )}
+                    </Listbox.Option>
+                  ))}
+                </Listbox.Options>
+              </Transition>
+            </div>
+          </>
+        )}
+      </Listbox>
+    </>
+  )
+}


### PR DESCRIPTION
A new component was created to handle the select dropdowns using Headless UI To use it, it is necessary to import the React-Hook-Form "Controller" component The Controller component is used to integrate the Headless UI select with the React-Hook-Form It receives the name of the field, the control object, the options and the label