### PR TITLE
feat(backend): Create endpoints to access and manipulate the database

### DIFF
--- a/icpc-backend/src/app.module.ts
+++ b/icpc-backend/src/app.module.ts
@@ -8,6 +8,10 @@ import { CategoriesModule } from './categories/categories.module';
 import { NotesModule } from './notes/notes.module';
 import { CommentModule } from './comment/comment.module';
 import { ConfigModule } from '@nestjs/config';
+import { MemoryModule } from './memory/memory.module';
+import { TimeModule } from './time/time.module';
+import { DifficultyModule } from './difficulty/difficulty.module';
+import { TagsModule } from './tags/tags.module';
 
 @Module({
   imports: [
@@ -31,7 +35,11 @@ import { ConfigModule } from '@nestjs/config';
     RolesModule,
     CategoriesModule,
     NotesModule,
-    CommentModule
+    CommentModule,
+    MemoryModule,
+    TimeModule,
+    DifficultyModule,
+    TagsModule
   ]
 })
 export class AppModule {

--- a/icpc-backend/src/categories/categories.controller.spec.ts
+++ b/icpc-backend/src/categories/categories.controller.spec.ts
@@ -8,7 +8,7 @@ describe('CategoriesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CategoriesController],
-      providers: [CategoriesService],
+      providers: [CategoriesService]
     }).compile();
 
     controller = module.get<CategoriesController>(CategoriesController);

--- a/icpc-backend/src/categories/categories.service.spec.ts
+++ b/icpc-backend/src/categories/categories.service.spec.ts
@@ -6,7 +6,7 @@ describe('CategoriesService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoriesService],
+      providers: [CategoriesService]
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);

--- a/icpc-backend/src/comment/comment.controller.spec.ts
+++ b/icpc-backend/src/comment/comment.controller.spec.ts
@@ -8,7 +8,7 @@ describe('CommentController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CommentController],
-      providers: [CommentService],
+      providers: [CommentService]
     }).compile();
 
     controller = module.get<CommentController>(CommentController);

--- a/icpc-backend/src/difficulty/difficulty.controller.spec.ts
+++ b/icpc-backend/src/difficulty/difficulty.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DifficultyController } from './difficulty.controller';
+import { DifficultyService } from './difficulty.service';
+
+describe('DifficultyController', () => {
+  let controller: DifficultyController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DifficultyController],
+      providers: [DifficultyService]
+    }).compile();
+
+    controller = module.get<DifficultyController>(DifficultyController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/icpc-backend/src/difficulty/difficulty.controller.ts
+++ b/icpc-backend/src/difficulty/difficulty.controller.ts
@@ -1,0 +1,93 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards
+} from '@nestjs/common';
+import { DifficultyService } from './difficulty.service';
+import { CreateDifficultyDto } from './dto/create-difficulty.dto';
+import { UpdateDifficultyDto } from './dto/update-difficulty.dto';
+import {
+  ApiBearerAuth,
+  ApiInternalServerErrorResponse,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse
+} from '@nestjs/swagger';
+import { Auth } from 'src/common/decorators/auth.decorator';
+import { RoleEnum } from 'src/common/enums/role.enum';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+
+@Auth(RoleEnum.ADMIN)
+@ApiTags('Difficulty')
+@Controller('difficulty')
+export class DifficultyController {
+  constructor(private readonly difficultyService: DifficultyService) {}
+
+  @ApiBearerAuth()
+  @Post()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The difficulty level has been successfully created.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  create(@Body() createDifficultyDto: CreateDifficultyDto) {
+    return this.difficultyService.create(createDifficultyDto);
+  }
+
+  @ApiBearerAuth()
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The difficulty level list has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findAll() {
+    return this.difficultyService.findAll();
+  }
+
+  @ApiBearerAuth()
+  @Get(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The difficulty level has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findOne(@Param('id') id: string) {
+    return this.difficultyService.findOne(id);
+  }
+
+  @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The difficulty level has been successfully updated.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  update(
+    @Param('id') id: string,
+    @Body() updateDifficultyDto: UpdateDifficultyDto
+  ) {
+    return this.difficultyService.update(id, updateDifficultyDto);
+  }
+
+  @ApiBearerAuth()
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The difficulty level has been successfully deleted.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  remove(@Param('id') id: string) {
+    return this.difficultyService.remove(id);
+  }
+}

--- a/icpc-backend/src/difficulty/difficulty.module.ts
+++ b/icpc-backend/src/difficulty/difficulty.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DifficultyService } from './difficulty.service';
+import { DifficultyController } from './difficulty.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Difficulty } from './entities/difficulty.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Difficulty])],
+  controllers: [DifficultyController],
+  providers: [DifficultyService],
+  exports: [DifficultyService]
+})
+export class DifficultyModule {}

--- a/icpc-backend/src/difficulty/difficulty.service.spec.ts
+++ b/icpc-backend/src/difficulty/difficulty.service.spec.ts
@@ -1,15 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CommentService } from './comment.service';
+import { DifficultyService } from './difficulty.service';
 
-describe('CommentService', () => {
-  let service: CommentService;
+describe('DifficultyService', () => {
+  let service: DifficultyService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CommentService]
+      providers: [DifficultyService]
     }).compile();
 
-    service = module.get<CommentService>(CommentService);
+    service = module.get<DifficultyService>(DifficultyService);
   });
 
   it('should be defined', () => {

--- a/icpc-backend/src/difficulty/difficulty.service.ts
+++ b/icpc-backend/src/difficulty/difficulty.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { CreateDifficultyDto } from './dto/create-difficulty.dto';
+import { UpdateDifficultyDto } from './dto/update-difficulty.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Difficulty } from './entities/difficulty.entity';
+
+@Injectable()
+export class DifficultyService {
+  constructor(
+    @InjectRepository(Difficulty)
+    private readonly difficultyRepository: Repository<Difficulty>
+  ) {}
+
+  async create(createDifficultyDto: CreateDifficultyDto) {
+    return await this.difficultyRepository.save(createDifficultyDto);
+  }
+
+  async findAll() {
+    return await this.difficultyRepository.find();
+  }
+
+  async findOne(id: string) {
+    return await this.difficultyRepository.findOneBy({ id });
+  }
+
+  async update(id: string, updateDifficultyDto: UpdateDifficultyDto) {
+    const difficulty = await this.difficultyRepository.findOneBy({ id });
+    return await this.difficultyRepository.save({
+      ...difficulty,
+      ...updateDifficultyDto
+    });
+  }
+
+  async remove(id: string) {
+    const difficulty = await this.difficultyRepository.findOneBy({ id });
+    return await this.difficultyRepository.remove(difficulty);
+  }
+}

--- a/icpc-backend/src/difficulty/dto/create-difficulty.dto.ts
+++ b/icpc-backend/src/difficulty/dto/create-difficulty.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString } from 'class-validator';
+
+export class CreateDifficultyDto {
+  @ApiProperty()
+  @IsNumber()
+  level: number;
+
+  @ApiProperty()
+  @IsString()
+  name: string;
+}

--- a/icpc-backend/src/difficulty/dto/update-difficulty.dto.ts
+++ b/icpc-backend/src/difficulty/dto/update-difficulty.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateDifficultyDto } from './create-difficulty.dto';
+
+export class UpdateDifficultyDto extends PartialType(CreateDifficultyDto) {}

--- a/icpc-backend/src/difficulty/entities/difficulty.entity.ts
+++ b/icpc-backend/src/difficulty/entities/difficulty.entity.ts
@@ -1,0 +1,11 @@
+import { BaseEntity } from 'src/entities/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity()
+export class Difficulty extends BaseEntity {
+  @Column({ nullable: false, unique: true })
+  level: number;
+
+  @Column({ nullable: false, unique: true })
+  name: string;
+}

--- a/icpc-backend/src/memory/dto/create-memory.dto.ts
+++ b/icpc-backend/src/memory/dto/create-memory.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class CreateMemoryDto {
+  @ApiProperty()
+  @IsNumber()
+  memoryLimit: number;
+}

--- a/icpc-backend/src/memory/dto/update-memory.dto.ts
+++ b/icpc-backend/src/memory/dto/update-memory.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateMemoryDto } from './create-memory.dto';
+
+export class UpdateMemoryDto extends PartialType(CreateMemoryDto) {}

--- a/icpc-backend/src/memory/entities/memory.entity.ts
+++ b/icpc-backend/src/memory/entities/memory.entity.ts
@@ -2,7 +2,7 @@ import { BaseEntity } from 'src/entities/base.entity';
 import { Column, Entity } from 'typeorm';
 
 @Entity()
-export class Comment extends BaseEntity {
-  @Column({ nullable: false })
-  body: string;
+export class Memory extends BaseEntity {
+  @Column({ nullable: false, unique: true })
+  memoryLimit: number;
 }

--- a/icpc-backend/src/memory/memory.controller.spec.ts
+++ b/icpc-backend/src/memory/memory.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MemoryController } from './memory.controller';
+import { MemoryService } from './memory.service';
+
+describe('MemoryController', () => {
+  let controller: MemoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MemoryController],
+      providers: [MemoryService]
+    }).compile();
+
+    controller = module.get<MemoryController>(MemoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/icpc-backend/src/memory/memory.controller.ts
+++ b/icpc-backend/src/memory/memory.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards
+} from '@nestjs/common';
+import { MemoryService } from './memory.service';
+import { CreateMemoryDto } from './dto/create-memory.dto';
+import { UpdateMemoryDto } from './dto/update-memory.dto';
+import {
+  ApiBearerAuth,
+  ApiResponse,
+  ApiInternalServerErrorResponse,
+  ApiTags,
+  ApiUnauthorizedResponse
+} from '@nestjs/swagger';
+import { Auth } from 'src/common/decorators/auth.decorator';
+import { RoleEnum } from 'src/common/enums/role.enum';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+
+@Controller('memory')
+@Auth(RoleEnum.ADMIN)
+@ApiTags('Memory')
+export class MemoryController {
+  constructor(private readonly memoryService: MemoryService) {}
+
+  @ApiBearerAuth()
+  @Post()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The memory limit has been successfully created.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  create(@Body() createMemoryDto: CreateMemoryDto) {
+    return this.memoryService.create(createMemoryDto);
+  }
+
+  @ApiBearerAuth()
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The memory limit list has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findAll() {
+    return this.memoryService.findAll();
+  }
+
+  @ApiBearerAuth()
+  @Get(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The memory limit has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findOne(@Param('id') id: string) {
+    return this.memoryService.findOne(id);
+  }
+
+  @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The memory limit has been successfully updated.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  update(@Param('id') id: string, @Body() updateMemoryDto: UpdateMemoryDto) {
+    return this.memoryService.update(id, updateMemoryDto);
+  }
+
+  @ApiBearerAuth()
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The memory limit has been successfully deleted.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  remove(@Param('id') id: string) {
+    return this.memoryService.remove(id);
+  }
+}

--- a/icpc-backend/src/memory/memory.module.ts
+++ b/icpc-backend/src/memory/memory.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MemoryService } from './memory.service';
+import { MemoryController } from './memory.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Memory } from './entities/memory.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Memory])],
+  controllers: [MemoryController],
+  providers: [MemoryService],
+  exports: [MemoryService]
+})
+export class MemoryModule {}

--- a/icpc-backend/src/memory/memory.service.spec.ts
+++ b/icpc-backend/src/memory/memory.service.spec.ts
@@ -1,15 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CommentService } from './comment.service';
+import { MemoryService } from './memory.service';
 
-describe('CommentService', () => {
-  let service: CommentService;
+describe('MemoryService', () => {
+  let service: MemoryService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CommentService]
+      providers: [MemoryService]
     }).compile();
 
-    service = module.get<CommentService>(CommentService);
+    service = module.get<MemoryService>(MemoryService);
   });
 
   it('should be defined', () => {

--- a/icpc-backend/src/memory/memory.service.ts
+++ b/icpc-backend/src/memory/memory.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { CreateMemoryDto } from './dto/create-memory.dto';
+import { UpdateMemoryDto } from './dto/update-memory.dto';
+import { Memory } from './entities/memory.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class MemoryService {
+  constructor(
+    @InjectRepository(Memory)
+    private readonly memoryRepository: Repository<Memory>
+  ) {}
+
+  async create(createMemoryDto: CreateMemoryDto) {
+    const newVal = await this.memoryRepository.save(createMemoryDto);
+    return {
+      id: newVal.id,
+      memoryLimit: newVal.memoryLimit
+    };
+  }
+
+  async findAll() {
+    return await this.memoryRepository.find();
+  }
+
+  async findOne(id: string) {
+    return await this.memoryRepository.findOneBy({ id });
+  }
+
+  async update(id: string, updateMemoryDto: UpdateMemoryDto) {
+    const memory = await this.memoryRepository.findOneBy({ id });
+    return await this.memoryRepository.save({ ...memory, ...updateMemoryDto });
+  }
+
+  async remove(id: string) {
+    const memory = await this.memoryRepository.findOneBy({ id });
+    return await this.memoryRepository.remove(memory);
+  }
+}

--- a/icpc-backend/src/tags/dto/create-tag.dto.ts
+++ b/icpc-backend/src/tags/dto/create-tag.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateTagDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  @MinLength(6)
+  @MaxLength(6)
+  color: string;
+}

--- a/icpc-backend/src/tags/dto/update-tag.dto.ts
+++ b/icpc-backend/src/tags/dto/update-tag.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTagDto } from './create-tag.dto';
+
+export class UpdateTagDto extends PartialType(CreateTagDto) {}

--- a/icpc-backend/src/tags/entities/tag.entity.ts
+++ b/icpc-backend/src/tags/entities/tag.entity.ts
@@ -1,0 +1,11 @@
+import { BaseEntity } from 'src/entities/base.entity';
+import { Column, Entity } from 'typeorm';
+
+@Entity()
+export class Tag extends BaseEntity {
+  @Column({ nullable: false, unique: true })
+  name: string;
+
+  @Column({ nullable: false, unique: true })
+  color: string;
+}

--- a/icpc-backend/src/tags/tags.controller.spec.ts
+++ b/icpc-backend/src/tags/tags.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagsController } from './tags.controller';
+import { TagsService } from './tags.service';
+
+describe('TagsController', () => {
+  let controller: TagsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagsController],
+      providers: [TagsService]
+    }).compile();
+
+    controller = module.get<TagsController>(TagsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/icpc-backend/src/tags/tags.controller.ts
+++ b/icpc-backend/src/tags/tags.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards
+} from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import {
+  ApiBearerAuth,
+  ApiResponse,
+  ApiUnauthorizedResponse,
+  ApiInternalServerErrorResponse,
+  ApiTags
+} from '@nestjs/swagger';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+import { Auth } from 'src/common/decorators/auth.decorator';
+import { RoleEnum } from 'src/common/enums/role.enum';
+
+@Auth(RoleEnum.ADMIN)
+@ApiTags('Tags')
+@Controller('tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @ApiBearerAuth()
+  @Post()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The tag has been successfully created.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  create(@Body() createTagDto: CreateTagDto) {
+    return this.tagsService.create(createTagDto);
+  }
+
+  @ApiBearerAuth()
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The tag list has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findAll() {
+    return this.tagsService.findAll();
+  }
+
+  @ApiBearerAuth()
+  @Get(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The tag has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findOne(@Param('id') id: string) {
+    return this.tagsService.findOne(id);
+  }
+
+  @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The tag has been successfully updated.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  update(@Param('id') id: string, @Body() updateTagDto: UpdateTagDto) {
+    return this.tagsService.update(id, updateTagDto);
+  }
+
+  @ApiBearerAuth()
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The tag has been successfully deleted.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  remove(@Param('id') id: string) {
+    return this.tagsService.remove(id);
+  }
+}

--- a/icpc-backend/src/tags/tags.module.ts
+++ b/icpc-backend/src/tags/tags.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tag } from './entities/tag.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
+  controllers: [TagsController],
+  providers: [TagsService],
+  exports: [TagsService]
+})
+export class TagsModule {}

--- a/icpc-backend/src/tags/tags.service.spec.ts
+++ b/icpc-backend/src/tags/tags.service.spec.ts
@@ -1,15 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CommentService } from './comment.service';
+import { TagsService } from './tags.service';
 
-describe('CommentService', () => {
-  let service: CommentService;
+describe('TagsService', () => {
+  let service: TagsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CommentService]
+      providers: [TagsService]
     }).compile();
 
-    service = module.get<CommentService>(CommentService);
+    service = module.get<TagsService>(TagsService);
   });
 
   it('should be defined', () => {

--- a/icpc-backend/src/tags/tags.service.ts
+++ b/icpc-backend/src/tags/tags.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Tag } from './entities/tag.entity';
+
+@Injectable()
+export class TagsService {
+  constructor(
+    @InjectRepository(Tag)
+    private readonly tagRepository: Repository<Tag>
+  ) {}
+
+  async create(createTagDto: CreateTagDto) {
+    return await this.tagRepository.save(createTagDto);
+  }
+
+  async findAll() {
+    return await this.tagRepository.find();
+  }
+
+  async findOne(id: string) {
+    return await this.tagRepository.findOneBy({ id });
+  }
+
+  async update(id: string, updateTagDto: UpdateTagDto) {
+    const tag = await this.tagRepository.findOneBy({ id });
+    return await this.tagRepository.save({ ...tag, ...updateTagDto });
+  }
+
+  async remove(id: string) {
+    const tag = await this.tagRepository.findOneBy({ id });
+    return await this.tagRepository.remove(tag);
+  }
+}

--- a/icpc-backend/src/time/dto/create-time.dto.ts
+++ b/icpc-backend/src/time/dto/create-time.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber } from 'class-validator';
+
+export class CreateTimeDto {
+  @ApiProperty()
+  @IsNumber()
+  timeLimit: number;
+}

--- a/icpc-backend/src/time/dto/update-time.dto.ts
+++ b/icpc-backend/src/time/dto/update-time.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTimeDto } from './create-time.dto';
+
+export class UpdateTimeDto extends PartialType(CreateTimeDto) {}

--- a/icpc-backend/src/time/entities/time.entity.ts
+++ b/icpc-backend/src/time/entities/time.entity.ts
@@ -2,7 +2,7 @@ import { BaseEntity } from 'src/entities/base.entity';
 import { Column, Entity } from 'typeorm';
 
 @Entity()
-export class Comment extends BaseEntity {
-  @Column({ nullable: false })
-  body: string;
+export class Time extends BaseEntity {
+  @Column({ nullable: false, unique: true })
+  timeLimit: number;
 }

--- a/icpc-backend/src/time/time.controller.spec.ts
+++ b/icpc-backend/src/time/time.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TimeController } from './time.controller';
+import { TimeService } from './time.service';
+
+describe('TimeController', () => {
+  let controller: TimeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TimeController],
+      providers: [TimeService]
+    }).compile();
+
+    controller = module.get<TimeController>(TimeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/icpc-backend/src/time/time.controller.ts
+++ b/icpc-backend/src/time/time.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseGuards
+} from '@nestjs/common';
+import { TimeService } from './time.service';
+import { CreateTimeDto } from './dto/create-time.dto';
+import { UpdateTimeDto } from './dto/update-time.dto';
+import { Auth } from 'src/common/decorators/auth.decorator';
+import { RoleEnum } from 'src/common/enums/role.enum';
+import {
+  ApiBearerAuth,
+  ApiInternalServerErrorResponse,
+  ApiResponse,
+  ApiTags,
+  ApiUnauthorizedResponse
+} from '@nestjs/swagger';
+import { AuthGuard } from 'src/auth/guard/auth.guard';
+
+@Controller('time')
+@Auth(RoleEnum.ADMIN)
+@ApiTags('Time')
+export class TimeController {
+  constructor(private readonly timeService: TimeService) {}
+
+  @ApiBearerAuth()
+  @Post()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The time limit has been successfully created.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  create(@Body() createTimeDto: CreateTimeDto) {
+    return this.timeService.create(createTimeDto);
+  }
+
+  @ApiBearerAuth()
+  @Get()
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The time limit list has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findAll() {
+    return this.timeService.findAll();
+  }
+
+  @ApiBearerAuth()
+  @Get(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The time limit has been successfully retrieved.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  findOne(@Param('id') id: string) {
+    return this.timeService.findOne(id);
+  }
+
+  @ApiBearerAuth()
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The time limit has been successfully updated.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  update(@Param('id') id: string, @Body() updateTimeDto: UpdateTimeDto) {
+    return this.timeService.update(id, updateTimeDto);
+  }
+
+  @ApiBearerAuth()
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  @ApiResponse({
+    description: 'The time limit has been successfully deleted.'
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiInternalServerErrorResponse({ description: 'Internal Server Error' })
+  remove(@Param('id') id: string) {
+    return this.timeService.remove(id);
+  }
+}

--- a/icpc-backend/src/time/time.module.ts
+++ b/icpc-backend/src/time/time.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TimeService } from './time.service';
+import { TimeController } from './time.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Time } from './entities/time.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Time])],
+  controllers: [TimeController],
+  providers: [TimeService],
+  exports: [TimeService]
+})
+export class TimeModule {}

--- a/icpc-backend/src/time/time.service.spec.ts
+++ b/icpc-backend/src/time/time.service.spec.ts
@@ -1,15 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CommentService } from './comment.service';
+import { TimeService } from './time.service';
 
-describe('CommentService', () => {
-  let service: CommentService;
+describe('TimeService', () => {
+  let service: TimeService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CommentService]
+      providers: [TimeService]
     }).compile();
 
-    service = module.get<CommentService>(CommentService);
+    service = module.get<TimeService>(TimeService);
   });
 
   it('should be defined', () => {

--- a/icpc-backend/src/time/time.service.ts
+++ b/icpc-backend/src/time/time.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTimeDto } from './dto/create-time.dto';
+import { UpdateTimeDto } from './dto/update-time.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Time } from './entities/time.entity';
+
+@Injectable()
+export class TimeService {
+  constructor(
+    @InjectRepository(Time)
+    private readonly timeRepository: Repository<Time>
+  ) {}
+
+  async create(createTimeDto: CreateTimeDto) {
+    const newVal = await this.timeRepository.save(createTimeDto);
+    return {
+      id: newVal.id,
+      timeLimit: newVal.timeLimit
+    };
+  }
+
+  async findAll() {
+    return await this.timeRepository.find();
+  }
+
+  async findOne(id: string) {
+    return await this.timeRepository.findOneBy({ id });
+  }
+
+  async update(id: string, updateTimeDto: UpdateTimeDto) {
+    const time = await this.timeRepository.findOneBy({ id });
+    return await this.timeRepository.save({ ...time, ...updateTimeDto });
+  }
+
+  async remove(id: string) {
+    const time = await this.timeRepository.findOneBy({ id });
+    return await this.timeRepository.remove(time);
+  }
+}

--- a/icpc-backend/test/app.e2e-spec.ts
+++ b/icpc-backend/test/app.e2e-spec.ts
@@ -8,7 +8,7 @@ describe('AppController (e2e)', () => {
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [AppModule]
     }).compile();
 
     app = moduleFixture.createNestApplication();


### PR DESCRIPTION
Created endpoints for the following tables:
"Memory" for the memory limit of exercises
"Time" for the time limit of exercises
"Difficulty" for the difficulty level of exercises
"Tags" for the tags of exercises and notes

All endpoints perform the basic CRUD operations
All endpoints were tested through the Swagger UI