### PR TITLE
fix(NoteBodyLength): Use a text column to store the note's body

### DIFF
--- a/icpc-backend/src/notes/entities/note.entity.ts
+++ b/icpc-backend/src/notes/entities/note.entity.ts
@@ -30,7 +30,7 @@ export class Note extends BaseEntity {
   @JoinTable()
   tags: Tag[];
 
-  @Column({ nullable: false })
+  @Column('text', { nullable: false })
   body: string;
 
   @Column({ nullable: false })


### PR DESCRIPTION
The MySQL datatype for the note's body has been changed from the default VARCHAR to TEXT to extend the character limit from 255 to 65536