### PR TITLE
feat(Ticket Page): fix the recovery of the tags included in the notes

### DIFF
--- a/icpc-backend/src/news/news.controller.ts
+++ b/icpc-backend/src/news/news.controller.ts
@@ -59,16 +59,6 @@ export class NewsController {
     return this.newsService.findOne(id);
   }
 
-  @Get('latest')
-  @ApiCreatedResponse({
-    description: 'Las últimas noticias se han obtenido exitosamente.'
-  })
-  @ApiBadRequestResponse({ description: 'Error en la petición' })
-  @ApiInternalServerErrorResponse({ description: 'Error interno del servidor' })
-  findLatest() {
-    return this.newsService.findLatest();
-  }
-
   @Patch(':id')
   @ApiBearerAuth()
   @UseGuards(AuthGuard)
@@ -93,9 +83,5 @@ export class NewsController {
   @ApiInternalServerErrorResponse({ description: 'Internal server error' })
   remove(@Param('id') id: string) {
     return this.newsService.remove(id);
-  }
-  @Get('latest')
-  findLatest() {
-    return this.newsService.latest();
   }
 }

--- a/icpc-backend/src/news/news.service.ts
+++ b/icpc-backend/src/news/news.service.ts
@@ -71,18 +71,6 @@ export class NewsService {
     return res;
   }
 
-  async latest() {
-    const res = await this.newsRepository
-      .createQueryBuilder('news')
-      .leftJoinAndSelect('news.imageId', 'image')
-      .select(['news', 'image.id'])
-      .where('news.isVisible = :isVisible', { isVisible: true })
-      .orderBy('news.created_at', 'DESC')
-      .limit(3)
-      .getMany();
-    return res;
-  }
-
   async findOne(id: string) {
     const res = await this.newsRepository
       .createQueryBuilder('news')
@@ -90,18 +78,6 @@ export class NewsService {
       .select(['news', 'image.id'])
       .where('news.id = :newsId', { newsId: id })
       .getOne();
-    return res;
-  }
-
-  async findLatest() {
-    const res = await this.newsRepository
-      .createQueryBuilder('news')
-      .leftJoinAndSelect('news.imageId', 'image')
-      .select(['news', 'image.id'])
-      .where('news.isVisible = :isVisible', { isVisible: true })
-      .orderBy('news.created_at', 'DESC')
-      .limit(3)
-      .getMany();
     return res;
   }
 

--- a/icpc-backend/src/ticket/ticket.service.ts
+++ b/icpc-backend/src/ticket/ticket.service.ts
@@ -160,15 +160,19 @@ export class TicketService {
               .leftJoinAndSelect('ticket.originalNoteId', 'originalNoteId')
               .leftJoinAndSelect('originalNoteId.commentId', 'comment')
               .leftJoinAndSelect('originalNoteId.category', 'category')
+              .leftJoinAndSelect('originalNoteId.tags', 'tags')
               .leftJoinAndSelect('ticket.modifiedNoteId', 'modifiedNoteId')
               .leftJoinAndSelect('modifiedNoteId.commentId', 'comment')
               .leftJoinAndSelect('modifiedNoteId.category', 'category')
+              .leftJoinAndSelect('originalNoteId.tags', 'tags')
               .getOne()
           : await this.ticketRepository
               .createQueryBuilder('ticket')
               .where('ticket.id = :id', { id: id })
               .leftJoinAndSelect('ticket.originalNoteId', 'originalNoteId')
               .leftJoinAndSelect('originalNoteId.commentId', 'comment')
+              .leftJoinAndSelect('originalNoteId.category', 'category')
+              .leftJoinAndSelect('originalNoteId.tags', 'tags')
               .getOne();
       case TicketType.NEWS:
         return ticket.operation == TicketOperation.UPDATE

--- a/icpc-frontned/src/app/components/cards/NoteCardComponent.tsx
+++ b/icpc-frontned/src/app/components/cards/NoteCardComponent.tsx
@@ -4,17 +4,14 @@ import { TextComponent } from '../text/TextComponent'
 import TagListComponent from '../tags/TagListComponent'
 import { ButtonComponent } from '../buttons/ButtonComponent'
 import MarkdownBodyComponent from '../panels/MarkdownBodyComponent'
+import { Tags } from '@/constants/types'
 
 interface NoteCardProps {
   title: string
   description: string
   content: string
   showButton: boolean
-  tags: {
-    id: number
-    name: string
-    color: string
-  }[]
+  tags: Tags[]
 }
 
 /*

--- a/icpc-frontned/src/app/components/tags/TagListComponent.tsx
+++ b/icpc-frontned/src/app/components/tags/TagListComponent.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 import TagComponent from './TagComponent'
 import cn from 'classnames'
+import { Tags } from '@/constants/types'
 
 interface TagListProps {
-  tags: {
-    id: number
-    name: string
-    color: string
-  }[]
+  tags: Tags[]
   showIcon: boolean
   className?: string
 }
@@ -26,9 +23,9 @@ const TagListComponent = ({ ...props }: Readonly<TagListProps>) => {
   const style = cn('flex flex-wrap gap-x-2', props.className)
   return (
     <div className={style}>
-      {props.tags.map(tag => (
+      {props.tags.map((tag, index) => (
         <TagComponent
-          key={tag.id}
+          key={index}
           tagName={tag.name}
           color={tag.color}
           showIcon={props.showIcon}

--- a/icpc-frontned/src/store/useNewsStore.ts
+++ b/icpc-frontned/src/store/useNewsStore.ts
@@ -21,9 +21,9 @@ interface NewsState {
 }
 
 interface Actions {
-  createNews: (news: ICreateNews) => Promise<IApiResponse | TResponseBasicError>;
-  getNews: (limit?: number) => Promise<News[]>;
-  getNewsArticle: (id: string) => Promise<News>;
+  createNews: (news: ICreateNews) => Promise<IApiResponse | TResponseBasicError>
+  getNews: (limit?: number) => Promise<News[]>
+  getNewsArticle: (id: string) => Promise<News>
 }
 
 const useNewsStore = create<Actions & NewsState>()(
@@ -64,19 +64,6 @@ const useNewsStore = create<Actions & NewsState>()(
             return { ...response.data, index: 0 }; // Devuelve la noticia específica
           } catch (error: any) {
             return error.response.data; // Maneja errores
-          }
-        },
-
-        getLatest: async (): Promise<News[]> => {
-          try {
-            const response = await api.get('api/v1/news/latest')
-            const latestNews = response.data.map((news: News, index: number) => {
-              return { ...news, index}
-            })
-            return latestNews;
-          }
-          catch (error: any) {
-            return error.response
           }
         }
       }),


### PR DESCRIPTION
- Joined the tag table to recover the tags of each note item.
- Removed the `/latest` route in the backend, which provoked an error when opening the landing page.
- Changed the TagListComponent's props to receive an array of Tags instead of using the old interface