### PR TITLE
fix(mailCheckRole): Check the role of the creator before sending mail

### DIFF
--- a/icpc-backend/src/excercises/excercises.service.ts
+++ b/icpc-backend/src/excercises/excercises.service.ts
@@ -175,12 +175,14 @@ export class ExcercisesService {
       commentId: commentId
     });
     const savedTicket = await this.ticketRepository.save(ticket);
-    this.mailerService.sendMail(
-      true,
-      'create',
-      savedExcercise.title,
-      'ejercicio'
-    );
+    if (createExcerciseDto.role !== 'admin') {
+      this.mailerService.sendMail(
+        true,
+        'create',
+        savedExcercise.title,
+        'ejercicio'
+      );
+    }
     // If the exercise and ticket were successfully saved, return the exercise object
     if (savedExcercise && savedTicket) {
       return savedExcercise;

--- a/icpc-backend/src/news/news.service.ts
+++ b/icpc-backend/src/news/news.service.ts
@@ -80,7 +80,14 @@ export class NewsService {
       const savedTicket = await this.ticketRepository.save(ticket);
       // If the ticket is successfully saved, send a mail notification and return the new item
       if (savedNews && savedTicket) {
-        this.mailerService.sendMail(true, 'create', savedNews.title, 'noticia');
+        if (createNewsDto.role !== 'admin') {
+          this.mailerService.sendMail(
+            true,
+            'create',
+            savedNews.title,
+            'noticia'
+          );
+        }
         return savedNews;
       } else {
         throw new BadRequestException('Error al crear la noticia');

--- a/icpc-backend/src/notes/notes.service.ts
+++ b/icpc-backend/src/notes/notes.service.ts
@@ -108,7 +108,9 @@ export class NotesService {
     const savedTicket = await this.ticketRepository.save(ticket);
     // If the ticket is successfully saved and the note is created, send a mail notification
     if (newNote && savedTicket) {
-      this.mailerService.sendMail(true, 'create', newNote.title, 'apunte');
+      if (createNoteDto.role !== 'admin') {
+        this.mailerService.sendMail(true, 'create', newNote.title, 'apunte');
+      }
       return {
         id: newNote.id,
         categoryId: newNote.category,


### PR DESCRIPTION
Perform a check of the role when creating an item. If an admin creates a new item, the email notification is not sent. This is in order to reduce the amount of emails sent during the database population and data entry